### PR TITLE
Fixes using the wrong value for the variable 'c'

### DIFF
--- a/src/BenchMTParser.cpp
+++ b/src/BenchMTParser.cpp
@@ -32,7 +32,7 @@ double BenchMTParser::DoBenchmark(const std::string& sExpr, long iCount)
    MTParser p;
    p.defineVar("a", &a);
    p.defineVar("b", &b);
-   p.defineVar("c", &b);
+   p.defineVar("c", &c);
 
    p.defineVar("x", &x);
    p.defineVar("y", &y);


### PR DESCRIPTION
Was causing trivial expressions like a+b+c to return the wrong result.